### PR TITLE
toString enhancement

### DIFF
--- a/duration.js
+++ b/duration.js
@@ -83,6 +83,20 @@ var Duration = (function () {
       if (milliseconds === 0) {
         return "0";
       }
+	  
+	  //weeks
+	  var weeks = Math.floor(milliseconds / week);
+	  if(weeks !== 0){
+		  milliseconds -= week * weeks;
+		  str += weeks.toString() + "w"
+	  }
+	  
+	  //days
+	  var days = Math.floor(milliseconds / day);
+	  if(days !== 0){
+		  milliseconds -= day * days;
+		  str += days.toString() + "d"
+	  }
 
       // hours
       var hours = Math.floor(milliseconds / hour);


### PR DESCRIPTION
Enhance toString to parse Weeks and Days.

The current toString method uses hours as the biggest unit of measure. On my case I'm ending up with a huge amount of hours, we should only use up to 23 hours, after we should switch to use days. And the same for days, after 6 days we should jump to 1 week.