### PR TITLE
add amd module definition pattern

### DIFF
--- a/duration.js
+++ b/duration.js
@@ -167,6 +167,15 @@ var Duration = (function () {
 
 }).call(this);
 
-if (typeof module !== "undefined") {
-   module.exports = Duration;
-}
+// module definition
+(function (root) {
+  if (typeof define === 'function' && define.amd) {
+    define([], function () {
+      return Duration;
+    });
+  } else if (typeof module !== "undefined") {
+     module.exports = Duration;
+  } else {
+    root.Duration = Duration;
+  }
+}).call(this);


### PR DESCRIPTION
Hi nice work, I added amd module definition.
By the way, from the Docs, this does not work in Browsers
var d     = Duration.parse("5h"),
    now   = new Date(),
    later = new Date(now + d);
console.log(later.toString());
need to use Date.now() + d